### PR TITLE
Fixes for queue name and defaults

### DIFF
--- a/glite-info-dynamic-condor
+++ b/glite-info-dynamic-condor
@@ -64,7 +64,7 @@ if [[ "$deployment" == "queue_to_schedd" ]]; then
   # Retrieve information for each queue
   #
   for queue in ${queues[@]}; do
-    queuename=`echo ${queue} | sed 's/[^a-zA-Z0-9_]/_/g'`
+    queuename=`echo ${queue} | grep -Eo '^[^@]+'`
     vardef="`$condorstatus -schedd $queue \
       -format "${queuename}_WaitingJobs=%s " TotalIdleJobs \\
       -format "${queuename}_RunningJobs=%s " TotalRunningJobs \\
@@ -83,7 +83,7 @@ elif [[ "$deployment" == "queue_to_jobattribute" ]]; then
   ##   The queue information are stored as variables in the configuration file
 
   for queue in ${queues[@]}; do
-    queuename=`echo ${queue} | sed 's/[^a-zA-Z0-9_]/_/g'`
+    queuename=`echo ${queue} | grep -Eo '^[^@]+'`
     eval "declare -i ${queuename}_TotalJobs=0"
     eval "declare -i ${queuename}_WaitingJobs=0"
     eval "declare -i ${queuename}_RunningJobs=0"
@@ -91,7 +91,7 @@ elif [[ "$deployment" == "queue_to_jobattribute" ]]; then
 
   constr="(JobStatus == 1 || JobStatus == 2)"
   while read queue status; do
-    queuename=`echo ${queue} | sed 's/[^a-zA-Z0-9_]/_/g'`
+    queuename=`echo ${queue} | grep -Eo '^[^@]+'`
     eval "let ${queuename}_TotalJobs+=1"
     if (( $status == 1 )); then
       eval "let ${queuename}_WaitingJobs+=1"
@@ -145,7 +145,7 @@ if [[ "$outputformat" == "glue1" || "$outputformat" == "both" ]]; then
   while read ldifline ; do
     queue=${ldifline##*cream-condor-}
     queue=${queue%%,*}
-    queuename=`echo ${queue} | sed 's/[^a-zA-Z0-9_]/_/g'`
+    queuename=`echo ${queue} | grep -Eo '^[^@]+'`
     glueline="\
 $ldifline
 GlueCEInfoLRMSType: condor
@@ -195,7 +195,7 @@ GLUE2ManagerProductVersion: $CondorVersion
   while read ldifline ; do
     queue=${ldifline##*GLUE2ShareID=}
     queue=${queue%%_*}
-    queuename=`echo ${queue} | sed 's/[^a-zA-Z0-9_]/_/g'`
+    queuename=`echo ${queue} | grep -Eo '^[^@]+'`
     glueline="\
 $ldifline
 GLUE2ComputingShareDefaultCPUTime: \${${queuename}_MaxCPUTime:-999999999}

--- a/glite-info-dynamic-condor
+++ b/glite-info-dynamic-condor
@@ -45,6 +45,8 @@ fi
 condorstatus="${condor_path:-/usr/bin}/condor_status ${condor_host:+-pool $condor_host}"
 condorq="${condor_path:-/usr/bin}/condor_q ${condor_host:+-pool $condor_host}"
 
+undefintvalue=999999999
+
 # How is the CE deployed?
 #
 
@@ -153,13 +155,13 @@ GlueCEPolicyAssignedJobSlots: $TotalSlots
 GlueCEInfoTotalCPUs: $TotalCpus
 GlueCEStateFreeCPUs: $FreeCpus
 GlueCEStateFreeJobSlots: $FreeSlots
-GlueCEStateWaitingJobs: \$${queuename}_WaitingJobs
-GlueCEStateRunningJobs: \$${queuename}_RunningJobs
-GlueCEStateTotalJobs: \$${queuename}_TotalJobs
-GlueCEPolicyMaxCPUTime: \$${queuename}_MaxCPUTime
-GlueCEPolicyMaxWallClockTime: \$${queuename}_MaxWallClockTime
-GlueCEPolicyMaxObtainableCPUTime: \$${queuename}_MaxCPUTime
-GlueCEPolicyMaxObtainableWallClockTime: \$${queuename}_MaxWallClockTime
+GlueCEStateWaitingJobs: \${${queuename}_WaitingJobs:-${undefintvalue}}
+GlueCEStateRunningJobs: \${${queuename}_RunningJobs:-${undefintvalue}}
+GlueCEStateTotalJobs: \${${queuename}_TotalJobs:-${undefintvalue}}
+GlueCEPolicyMaxCPUTime: \${${queuename}_MaxCPUTime:-${undefintvalue}}
+GlueCEPolicyMaxWallClockTime: \${${queuename}_MaxWallClockTime:-${undefintvalue}}
+GlueCEPolicyMaxObtainableCPUTime: \${${queuename}_MaxCPUTime:-${undefintvalue}}
+GlueCEPolicyMaxObtainableWallClockTime: \${${queuename}_MaxWallClockTime:-${undefintvalue}}
 GlueCEStateStatus: \$${queuename}_GlueStatus
 "
   eval "echo \"$glueline\""
@@ -196,16 +198,16 @@ GLUE2ManagerProductVersion: $CondorVersion
     queuename=${queue//\@/_}
     glueline="\
 $ldifline
-GLUE2ComputingShareDefaultCPUTime: \$${queuename}_MaxCPUTime
-GLUE2ComputingShareDefaultWallTime: \$${queuename}_MaxWallClockTime
-GLUE2ComputingShareMaxCPUTime: \$${queuename}_MaxCPUTime
-GLUE2ComputingShareMaxWallTime: \$${queuename}_MaxWallClockTime
-GLUE2ComputingShareMaxMainMemory: \$${queuename}_MaxMainMemory
-GLUE2ComputingShareMaxSlotsPerJob: \$${queuename}_MaxSlotsPerJob
-GLUE2ComputingShareMaxVirtualMemory: \$${queuename}_MaxVirtualMemory
-GLUE2ComputingShareServingState: \$(echo \$${queuename}_GlueStatus | tr [:upper:] [:lower:])
+GLUE2ComputingShareDefaultCPUTime: \${${queuename}_MaxCPUTime:-${undefintvalue}}
+GLUE2ComputingShareDefaultWallTime: \${${queuename}_MaxWallClockTime:-${undefintvalue}}
+GLUE2ComputingShareMaxCPUTime: \${${queuename}_MaxCPUTime:-${undefintvalue}}
+GLUE2ComputingShareMaxWallTime: \${${queuename}_MaxWallClockTime:-${undefintvalue}}
+GLUE2ComputingShareMaxMainMemory: \${${queuename}_MaxMainMemory:-${undefintvalue}}
+GLUE2ComputingShareMaxSlotsPerJob: \${${queuename}_MaxSlotsPerJob:-${undefintvalue}}
+GLUE2ComputingShareMaxVirtualMemory: \${${queuename}_MaxVirtualMemory:-${undefintvalue}}
+GLUE2ComputingShareServingState: \$(echo \${${queuename}_GlueStatus:-production} | tr [:upper:] [:lower:])
 GLUE2ComputingShareMaxRunningJobs: $TotalSlots
-GLUE2ComputingShareWaitingJobs: \$${queuename}_WaitingJobs
+GLUE2ComputingShareWaitingJobs: \${${queuename}_WaitingJobs:-${undefintvalue}}
 "
   eval "echo \"$glueline\""
   done

--- a/glite-info-dynamic-condor
+++ b/glite-info-dynamic-condor
@@ -45,8 +45,6 @@ fi
 condorstatus="${condor_path:-/usr/bin}/condor_status ${condor_host:+-pool $condor_host}"
 condorq="${condor_path:-/usr/bin}/condor_q ${condor_host:+-pool $condor_host}"
 
-undefintvalue=999999999
-
 # How is the CE deployed?
 #
 
@@ -66,7 +64,7 @@ if [[ "$deployment" == "queue_to_schedd" ]]; then
   # Retrieve information for each queue
   #
   for queue in ${queues[@]}; do
-    queuename=${queue//\@/_}
+    queuename=`echo ${queue} | sed 's/[^a-zA-Z0-9_]/_/g'`
     vardef="`$condorstatus -schedd $queue \
       -format "${queuename}_WaitingJobs=%s " TotalIdleJobs \\
       -format "${queuename}_RunningJobs=%s " TotalRunningJobs \\
@@ -84,14 +82,16 @@ elif [[ "$deployment" == "queue_to_jobattribute" ]]; then
   ## There is no relation between schedds and queues
   ##   The queue information are stored as variables in the configuration file
 
-  for queuename in ${queues[@]}; do
+  for queue in ${queues[@]}; do
+    queuename=`echo ${queue} | sed 's/[^a-zA-Z0-9_]/_/g'`
     eval "declare -i ${queuename}_TotalJobs=0"
     eval "declare -i ${queuename}_WaitingJobs=0"
     eval "declare -i ${queuename}_RunningJobs=0"
   done
 
   constr="(JobStatus == 1 || JobStatus == 2)"
-  while read queuename status; do
+  while read queue status; do
+    queuename=`echo ${queue} | sed 's/[^a-zA-Z0-9_]/_/g'`
     eval "let ${queuename}_TotalJobs+=1"
     if (( $status == 1 )); then
       eval "let ${queuename}_WaitingJobs+=1"
@@ -145,7 +145,7 @@ if [[ "$outputformat" == "glue1" || "$outputformat" == "both" ]]; then
   while read ldifline ; do
     queue=${ldifline##*cream-condor-}
     queue=${queue%%,*}
-    queuename=${queue//\@/_}
+    queuename=`echo ${queue} | sed 's/[^a-zA-Z0-9_]/_/g'`
     glueline="\
 $ldifline
 GlueCEInfoLRMSType: condor
@@ -155,14 +155,14 @@ GlueCEPolicyAssignedJobSlots: $TotalSlots
 GlueCEInfoTotalCPUs: $TotalCpus
 GlueCEStateFreeCPUs: $FreeCpus
 GlueCEStateFreeJobSlots: $FreeSlots
-GlueCEStateWaitingJobs: \${${queuename}_WaitingJobs:-${undefintvalue}}
-GlueCEStateRunningJobs: \${${queuename}_RunningJobs:-${undefintvalue}}
-GlueCEStateTotalJobs: \${${queuename}_TotalJobs:-${undefintvalue}}
-GlueCEPolicyMaxCPUTime: \${${queuename}_MaxCPUTime:-${undefintvalue}}
-GlueCEPolicyMaxWallClockTime: \${${queuename}_MaxWallClockTime:-${undefintvalue}}
-GlueCEPolicyMaxObtainableCPUTime: \${${queuename}_MaxCPUTime:-${undefintvalue}}
-GlueCEPolicyMaxObtainableWallClockTime: \${${queuename}_MaxWallClockTime:-${undefintvalue}}
-GlueCEStateStatus: \$${queuename}_GlueStatus
+GlueCEStateWaitingJobs: \${${queuename}_WaitingJobs:-444444}
+GlueCEStateRunningJobs: \${${queuename}_RunningJobs:-0}
+GlueCEStateTotalJobs: \${${queuename}_TotalJobs:-0}
+GlueCEPolicyMaxCPUTime: \${${queuename}_MaxCPUTime:-999999999}
+GlueCEPolicyMaxWallClockTime: \${${queuename}_MaxWallClockTime:-999999999}
+GlueCEPolicyMaxObtainableCPUTime: \${${queuename}_MaxCPUTime:-999999999}
+GlueCEPolicyMaxObtainableWallClockTime: \${${queuename}_MaxWallClockTime:-999999999}
+GlueCEStateStatus: \${${queuename}_GlueStatus:-Production}
 "
   eval "echo \"$glueline\""
   done
@@ -195,19 +195,19 @@ GLUE2ManagerProductVersion: $CondorVersion
   while read ldifline ; do
     queue=${ldifline##*GLUE2ShareID=}
     queue=${queue%%_*}
-    queuename=${queue//\@/_}
+    queuename=`echo ${queue} | sed 's/[^a-zA-Z0-9_]/_/g'`
     glueline="\
 $ldifline
-GLUE2ComputingShareDefaultCPUTime: \${${queuename}_MaxCPUTime:-${undefintvalue}}
-GLUE2ComputingShareDefaultWallTime: \${${queuename}_MaxWallClockTime:-${undefintvalue}}
-GLUE2ComputingShareMaxCPUTime: \${${queuename}_MaxCPUTime:-${undefintvalue}}
-GLUE2ComputingShareMaxWallTime: \${${queuename}_MaxWallClockTime:-${undefintvalue}}
-GLUE2ComputingShareMaxMainMemory: \${${queuename}_MaxMainMemory:-${undefintvalue}}
-GLUE2ComputingShareMaxSlotsPerJob: \${${queuename}_MaxSlotsPerJob:-${undefintvalue}}
-GLUE2ComputingShareMaxVirtualMemory: \${${queuename}_MaxVirtualMemory:-${undefintvalue}}
+GLUE2ComputingShareDefaultCPUTime: \${${queuename}_MaxCPUTime:-999999999}
+GLUE2ComputingShareDefaultWallTime: \${${queuename}_MaxWallClockTime:-999999999}
+GLUE2ComputingShareMaxCPUTime: \${${queuename}_MaxCPUTime:-999999999}
+GLUE2ComputingShareMaxWallTime: \${${queuename}_MaxWallClockTime:-999999999}
+GLUE2ComputingShareMaxMainMemory: \${${queuename}_MaxMainMemory:-444444}
+GLUE2ComputingShareMaxSlotsPerJob: \${${queuename}_MaxSlotsPerJob:-444444}
+GLUE2ComputingShareMaxVirtualMemory: \${${queuename}_MaxVirtualMemory:-444444}
 GLUE2ComputingShareServingState: \$(echo \${${queuename}_GlueStatus:-production} | tr [:upper:] [:lower:])
 GLUE2ComputingShareMaxRunningJobs: $TotalSlots
-GLUE2ComputingShareWaitingJobs: \${${queuename}_WaitingJobs:-${undefintvalue}}
+GLUE2ComputingShareWaitingJobs: \${${queuename}_WaitingJobs:-444444}
 "
   eval "echo \"$glueline\""
   done

--- a/info-dynamic-scheduler-condor.spec
+++ b/info-dynamic-scheduler-condor.spec
@@ -1,7 +1,7 @@
 Summary: Plugins for the lcg-info-dynamic-scheduler GIP plugin
 Name: lcg-info-dynamic-scheduler-condor
 Version: 1.0
-Release: 1.el7
+Release: 1%{?dist}
 License: Apache Software License
 Vendor: EMI
 URL: http://glite.cern.ch/


### PR DESCRIPTION
The fix removes the suffix of a queue name containing the host name with characters ('.', '-') that cannot be used inside a bash variable name.
Since bdii-updater complains about empty values for GLUE definitions, the patch makes use of default values if an item has not been calculated. I was not able to completely remove the item if its value is missing. It's a workaround